### PR TITLE
Add repo link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "spacetraders-sdk",
+  "repository": "https://github.com/notVitaliy/spacetraders-io.git",
   "version": "0.0.6",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Helps people find the source code from the npm package, rather than needing to dig through authorship