### PR TITLE
Use correct type for listSystems()

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ spaceTraders.listLocations(system?: string, type?: string): Promise<LocationsRes
 Get systems info
 
 ```typescript
-spaceTraders.listSystems(): Promise<LocationResponse>
+spaceTraders.listSystems(): Promise<SystemsResponse>
 ```
 
 ### [payBackLoan](https://api.spacetraders.io/#api-loans)

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   StatusResponse,
   TokenResponse,
   JettisonResponse,
+  SystemsResponse,
 } from './types'
 import { asyncSleep, asyncWrap } from './utils'
 
@@ -142,7 +143,7 @@ export class SpaceTraders {
   listSystems() {
     const url = '/game/systems'
 
-    return this.makeAuthRequest<LocationResponse>(url, 'get')
+    return this.makeAuthRequest<SystemsResponse>(url, 'get')
   }
 
   listLocations(system: string = 'OE', type?: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,7 +209,7 @@ export interface ShipsResponse {
 }
 
 export interface SystemsResponse {
-  systems: System
+  systems: System[]
 }
 
 export interface TokenResponse {


### PR DESCRIPTION
I noticed the return promise for listSystems was wrong, should be SystemsResponse instead of LocationResponse.

Here is the response for a listSystems()
```
{
    "systems": [
        {
            "symbol": "OE",
            "name": "Omicron Eridani",
            "locations": [...]
        },
        {
            "symbol": "XV",
            "name": "Xiav",
            "locations": [...]
        }
    ]
}
```