### PR TITLE
Remove duplicate users from path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -237,7 +237,7 @@ export class SpaceTraders {
 
   private async createUser(newUsername: string) {
     const path = this.makeUserPath(`${newUsername}/token`)
-    const url = `${BASE_URL}/users/${path}`
+    const url = `${BASE_URL}${path}`
 
     const resp = await axios.post<TokenResponse>(url)
 


### PR DESCRIPTION
This PR fixes an issue where `/users/` would be in the path two times, when I create a new user.

```
  const userId = uuid();
  const token = await spaceTraders.init(userId);
```

From the error logs:

```
  config: {
    url: 'https://api.spacetraders.io/users//users/REDACTED/REDACTED/token',
    method: 'post',

```

Tests executed: PR build scripts