### PR TITLE
Add breaking changes from April 25th, 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ Get info on a location
 spaceTraders.getLocation(location: string): Promise<LocationResponse>;
 ```
 
+### [getLocationShips](https://api.spacetraders.io/#api-locations-locationShips)
+
+Get info on a location's docked ships
+
+```typescript
+spaceTraders.getLocation(location: string): Promise<LocationShipResponse>
+```
+
 ### [getMarketplace](https://api.spacetraders.io/#api-marketplace-marketplace)
 
 Get info on a locations marketplace

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   StructureDepositResponse,
   StructureTransferResponse,
   ListStructuresResponse,
+  LocationShipsResponse,
 } from './types'
 import { asyncSleep, asyncWrap } from './utils'
 
@@ -233,6 +234,12 @@ export class SpaceTraders {
     const url = this.makeUserPath(`structures`)
 
     return this.makeAuthRequest<ListStructuresResponse>(url, 'get')
+  }
+
+  getLocationShips(location: string) {
+    const url = this.makeUserPath(`/game/locations/${location}/ships`)
+
+    return this.makeAuthRequest<LocationShipsResponse>(url, 'get')
   }
 
   private async createUser(newUsername: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,7 +214,12 @@ export interface JettisonResponse {
 }
 
 export interface LocationResponse {
+  dockedShips: number
   location: Location
+}
+
+export interface LocationShipsResponse {
+  ships: Ship[]
 }
 
 export interface LocationsResponse {


### PR DESCRIPTION
[* Add new getLocationShip() and LocationShipResponse interface](https://api.spacetraders.io/#api-locations-locationShips)
[* Add dockedships to the LocationResponse interface](https://api.spacetraders.io/#api-locations-location)

Of note from the breaking changelog: ```- (b) removed ships being included in location endpoint `/game/locations/:symbol`. Use `/game/locations/:symbol/ships` instead.``` doesn't apply, as we've never included ships in the LocationResponse interface anyways.