### PR TITLE
Fixed issues with creating a new user

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,9 +62,8 @@ export class SpaceTraders {
 
   async init(username: string, token?: string) {
     if (!username) throw new Error('Username is required.')
-    if (!token) return await this.createUser(username)
-
     this.username = username
+    if (!token) return await this.createUser()
     this.token = token
 
     return token
@@ -242,8 +241,8 @@ export class SpaceTraders {
     return this.makeAuthRequest<LocationShipsResponse>(url, 'get')
   }
 
-  private async createUser(newUsername: string) {
-    const path = this.makeUserPath(`${newUsername}/token`)
+  private async createUser() {
+    const path = this.makeUserPath(`/token`)
     const url = `${BASE_URL}${path}`
 
     const resp = await axios.post<TokenResponse>(url)


### PR DESCRIPTION
# Error Overview
When attempting to create a new user through the spacetraders.init, would receive the following error:
```
ⓧ POST https://api.spacetraders.io/users/null/duongc/token 401
```
Turns out the null is being created by this.createUser(...) function which relies on this.username, which is yet to assigned anything. Fixing this reveals this error:
```
ⓧ POST https://api.spacetraders.io/users/duongc/duongc/token 401
```
Changing to properly utilize this.createUser resolves all errors

# Changes
* Assign this.username sooner in the this.init(...) function
* Uses this.makeUserPath() function correctly